### PR TITLE
chore: add openzeppelin dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
   branch = "v1"
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,2 @@
 forge-std/=lib/forge-std/src/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts


### PR DESCRIPTION
## Description

This adds open zeppelin as a 3rd party dependency.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `yarn lint`?
- [ ] Ran `forge test`?
