### PR TITLE
chore(CI): ensure CI tasks are run on `develop` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - "main"
+      - "develop"
 
 jobs:
   lint:


### PR DESCRIPTION
Given that most of the work is currently happening in `develop` we should run CI tasks there.
Otherwise we'll have too much code additions that aren't reviewed by anyone.

Also, generally, it'd be cool @3esmit if you added your changes via pull requests. This gives other people on the team a chance to take a look and leave feedback.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
